### PR TITLE
Feat/original psp encoder

### DIFF
--- a/main.py
+++ b/main.py
@@ -275,6 +275,7 @@ class VToonifyHandler(BaseHandler): # for TorchServe  it need to inherit from Ba
         # frame_tensor, _ = self.vtoonify.generator([s_w], s_w, input_is_latent=True, randomize_noise=True, use_res=False)
         frame = ((frame_tensor[0].detach().cpu().numpy().transpose(1, 2, 0) + 1.0) * 127.5)
         # frame = frame_tensor.detach().cpu().numpy().astype(np.uint8)
+        # clip image to remove color spots on white background
         frame[frame < 0] = 0
         frame[frame > 255] = 255
 

--- a/main.py
+++ b/main.py
@@ -112,7 +112,7 @@ class VToonifyHandler(BaseHandler): # for TorchServe  it need to inherit from Ba
             vtoonify_path = "vtoonify_s_d.pt"
             faceparsing_path = "faceparsing.pth"
             face_landmark_modelname = 'shape_predictor_68_face_landmarks.dat'
-            style_encoder_path = "encoder.pt"
+            style_encoder_path = "encoder.pt" # pSp encoder url https://drive.google.com/file/d/1bMTNWkh5LArlaWSc_wa8VKyq2V42T2z0/view
             exstyle_path = "exstyle_code.npy"
             self.latent_mask = [10,11,12,13,14]
             self.style_degree = 0.0

--- a/main.py
+++ b/main.py
@@ -271,7 +271,7 @@ class VToonifyHandler(BaseHandler): # for TorchServe  it need to inherit from Ba
         return animation_frames
 
     def decodeFeaturesToImg(self, s_w):
-        frame_tensor, _ = self.vtoonify.generator.generator([s_w], input_is_latent=True, randomize_noise=True)
+        frame_tensor, _ = self.vtoonify.generator.generator([s_w], input_is_latent=True, randomize_noise=False)
         # frame_tensor, _ = self.vtoonify.generator([s_w], s_w, input_is_latent=True, randomize_noise=True, use_res=False)
         frame = ((frame_tensor[0].detach().cpu().numpy().transpose(1, 2, 0) + 1.0) * 127.5)
         # frame = frame_tensor.detach().cpu().numpy().astype(np.uint8)

--- a/main.py
+++ b/main.py
@@ -227,7 +227,6 @@ class VToonifyHandler(BaseHandler): # for TorchServe  it need to inherit from Ba
 
     def encode_face_img(self, face_image):
         s_w = self.pspencoder(face_image)
-        s_w = self.vtoonify.zplus2wplus(s_w)
 
         return s_w
 

--- a/main.py
+++ b/main.py
@@ -273,9 +273,12 @@ class VToonifyHandler(BaseHandler): # for TorchServe  it need to inherit from Ba
     def decodeFeaturesToImg(self, s_w):
         frame_tensor, _ = self.vtoonify.generator.generator([s_w], input_is_latent=True, randomize_noise=True)
         # frame_tensor, _ = self.vtoonify.generator([s_w], s_w, input_is_latent=True, randomize_noise=True, use_res=False)
-        frame = ((frame_tensor[0].detach().cpu().numpy().transpose(1, 2, 0) + 1.0) * 127.5).astype(np.uint8)
+        frame = ((frame_tensor[0].detach().cpu().numpy().transpose(1, 2, 0) + 1.0) * 127.5)
         # frame = frame_tensor.detach().cpu().numpy().astype(np.uint8)
-        return frame
+        frame[frame < 0] = 0
+        frame[frame > 255] = 255
+
+        return frame.astype(np.uint8)
 
     def apply_vtoonify(self, frame, s_w):
         # Compute VToonify Features


### PR DESCRIPTION
Use [pSp encoder from original repo](https://drive.google.com/file/d/1bMTNWkh5LArlaWSc_wa8VKyq2V42T2z0/view) for better results.
pSp encoder link: https://drive.google.com/file/d/1bMTNWkh5LArlaWSc_wa8VKyq2V42T2z0/view

For better results set `self.scale_image = False` at line 83. Need future PR to pass it as argument and to be able to pass it in the http request
