### PR TITLE
Fix: deprecated pillow antialias

### DIFF
--- a/model/encoder/align_all_parallel.py
+++ b/model/encoder/align_all_parallel.py
@@ -109,7 +109,7 @@ def align_face(filepath, predictor):
     shrink = int(np.floor(qsize / output_size * 0.5))
     if shrink > 1:
         rsize = (int(np.rint(float(img.size[0]) / shrink)), int(np.rint(float(img.size[1]) / shrink)))
-        img = img.resize(rsize, PIL.Image.ANTIALIAS)
+        img = img.resize(rsize, PIL.Image.LANCZOS)
         quad /= shrink
         qsize /= shrink
 
@@ -144,7 +144,7 @@ def align_face(filepath, predictor):
     # Transform.
     img = img.transform((transform_size, transform_size), PIL.Image.QUAD, (quad + 0.5).flatten(), PIL.Image.BILINEAR)
     if output_size < transform_size:
-        img = img.resize((output_size, output_size), PIL.Image.ANTIALIAS)
+        img = img.resize((output_size, output_size), PIL.Image.LANCZOS)
 
     # Save aligned image.
     return img


### PR DESCRIPTION
Error: `AttributeError: module 'PIL.Image' has no attribute 'ANTIALIAS'`
Reference link: https://stackoverflow.com/questions/76616042/attributeerror-module-pil-image-has-no-attribute-antialias

Use `PIL.Image.LANCZOS` instead